### PR TITLE
[#33] info.plist에 font 추가, SceneDelegate 수정, MainNavigationBar 수정

### DIFF
--- a/Mascota/Mascota/Resources/Constants/BookType.swift
+++ b/Mascota/Mascota/Resources/Constants/BookType.swift
@@ -20,13 +20,12 @@ enum BookType {
         }
     }
     
-    func text() -> String {
+    func titleFont() -> UIFont {
         switch self {
         case .home:
-            return "1부"
+            return .macoFont(type: .regular, size: 20)
         case .rainbow:
-            return "2부"
+            return .macoFont(type: .medium, size: 20)
         }
     }
-    
 }

--- a/Mascota/Mascota/Resources/Info.plist
+++ b/Mascota/Mascota/Resources/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>NotoSansCJKkr-Bold.otf</string>
+		<string>NotoSansCJKkr-Medium.otf</string>
+		<string>NotoSansCJKkr-Regular.otf</string>
+	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>UIUserInterfaceStyle</key>

--- a/Mascota/Mascota/Sources/Extensions/UIFont+Extension.swift
+++ b/Mascota/Mascota/Sources/Extensions/UIFont+Extension.swift
@@ -8,10 +8,8 @@
 import UIKit
 
 extension UIFont {
-    class func macoFont(type: NotoSansCJKkrType, size: CGFloat) -> UIFont! {
-        guard let font = UIFont(name: type.name, size: size) else {
-            return nil
-        }
+    class func macoFont(type: NotoSansCJKkrType, size: CGFloat) -> UIFont {
+        guard let font = UIFont(name: type.name, size: size) else { return .systemFont(ofSize: 3) }
         return font
     }
 

--- a/Mascota/Mascota/Sources/SceneDelegate.swift
+++ b/Mascota/Mascota/Sources/SceneDelegate.swift
@@ -21,11 +21,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             self.window = window
             
-            let navigationController = UINavigationController()
             let viewcontroller = RainbowViewController()
 //             let viewcontroller = UIStoryboard(name: "StoryboardTest", bundle: Bundle(for: StoryboardViewController.self)).instantiateViewController(withIdentifier: "storyboardVC") as! StoryboardViewController
-            navigationController.viewControllers = [viewcontroller]
-            window.rootViewController = viewcontroller
+            let rootNC = UINavigationController(rootViewController: viewcontroller)
+            window.rootViewController = rootNC
             window.backgroundColor = .macoIvory
             window.makeKeyAndVisible()
         }

--- a/Mascota/Mascota/Sources/View/MainNavigationBarView.swift
+++ b/Mascota/Mascota/Sources/View/MainNavigationBarView.swift
@@ -15,12 +15,11 @@ class MainNavigationBarView: UIView {
     
     private lazy var bookPartLabel = UILabel().then {
         $0.font = .boldSystemFont(ofSize: 20)
-        $0.text = type.text()
         $0.textColor = type.color()
     }
     
     private lazy var bookTitleLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 20)
+        $0.font = type.titleFont()
         $0.textColor = .macoBlack
     }
     
@@ -29,9 +28,8 @@ class MainNavigationBarView: UIView {
     public init(type: BookType) {
         super.init(frame: CGRect.zero)
         self.type = type
-        setNavigationBarView()
         
-        backgroundColor = .blue
+        setNavigationBarView()
     }
     
     required init?(coder: NSCoder) {
@@ -39,6 +37,8 @@ class MainNavigationBarView: UIView {
     }
     
     private func setNavigationBarView() {
+        backgroundColor = .macoIvory
+        
         addSubviews(bookPartLabel, bookTitleLabel, profileButton)
         
         profileButton.snp.makeConstraints {
@@ -61,9 +61,15 @@ class MainNavigationBarView: UIView {
     
     //  Public Function
 
-    public func setBookTitleLabel(text: String) {
+    public func setNavigationBarText(part: String? = nil, title: String) {
+        if let part = part {
+            _ = bookPartLabel.then {
+                $0.text = part
+            }
+        }
+        
         _ = bookTitleLabel.then {
-            $0.text = text.maxLength(length: 11)
+            $0.text = title.maxLength(length: 11)
         }
     }
 }


### PR DESCRIPTION
### Description
### info.plist에 font 추가
<img width="610" alt="스크린샷 2021-07-04 오후 9 58 45" src="https://user-images.githubusercontent.com/72497599/124385982-03097280-dd13-11eb-84e6-550e8c29136a.png">

### NavigationBar를 불러오지 못하는 문제 때문에 SceneDelegate수정
<img width="1063" alt="스크린샷 2021-07-04 오후 9 58 57" src="https://user-images.githubusercontent.com/72497599/124385986-0a308080-dd13-11eb-97cb-cf432025b620.png">

### 디자인 변경사항에 따라 part (1부,2부)가 사라지는 경우와 서버에서 넣어주는 경우에 대비하여 setNavigationBarText 생성
<img width="679" alt="스크린샷 2021-07-04 오후 9 59 12" src="https://user-images.githubusercontent.com/72497599/124385993-1288bb80-dd13-11eb-88b0-d36266ac84d6.png">


### Related Issues
#33 


Fixes #33 

